### PR TITLE
Add izone climate test for fault-shaped controller bootstrap

### DIFF
--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -6,6 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.izone.climate import ControllerDevice
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 
@@ -307,3 +308,19 @@ async def test_setup_entry_only_adds_entities_for_matching_config_entry(
     unique_ids = {entity.unique_id for entity in entry_entities}
 
     assert unique_ids == {"000000001", "000000001_z1"}
+
+
+def test_controller_device_init_fault_bootstrap() -> None:
+    """ControllerDevice survives bootstrap when controller has fault-shaped defaults."""
+    controller = create_mock_controller(
+        ras_mode="zones",
+        sys_type="0",
+        zones_total=0,
+        free_air_enabled=False,
+    )
+    controller.zones = []
+
+    device = ControllerDevice(controller)
+
+    assert device._attr_device_info["model"] == "0"
+    assert device.zones == {}


### PR DESCRIPTION
## Summary

- Adds `test_controller_device_init_fault_bootstrap` to verify `ControllerDevice` initializes when the controller exposes empty zone data and fault-shaped defaults (pizone 1.3.4 safe property reads).
- Stacked on #176341 (bump-only); no integration code changes.

## Test plan

- [x] `uv run pytest tests/components/izone/test_climate.py::test_controller_device_init_fault_bootstrap -v`


Made with [Cursor](https://cursor.com)